### PR TITLE
Remove redundant "docker" string in the command

### DIFF
--- a/docker-task/src/main/java/com/stacktoheap/go/docker/Commands/BuildCommands/DockerBuildCommand.java
+++ b/docker-task/src/main/java/com/stacktoheap/go/docker/Commands/BuildCommands/DockerBuildCommand.java
@@ -13,7 +13,6 @@ public class DockerBuildCommand extends DockerCommand {
 
     @Override
     public void buildCommand(Context taskContext, Config taskConfig) {
-        command.add("docker");
         command.add("build");
 
         command.add("-t");


### PR DESCRIPTION
The base DockerCommand class adds "docker" to the start for all command.

DockerBuildCommand also adds a superfluous "docker" creating the command `docker docker build`, which naturally fails.

This PR simply removes the unecessary "docker" from the command string.

PS! I'm no Java developer and found no testsuite or simple way of verifing that my reasoning of the problem at hand is correct.
